### PR TITLE
[issue_50] remove validation state listener on bean unregister

### DIFF
--- a/modules/core/org.jowidgets.cap.ui/src/main/java/org/jowidgets/cap/ui/impl/BeansStateTrackerImpl.java
+++ b/modules/core/org.jowidgets.cap.ui/src/main/java/org/jowidgets/cap/ui/impl/BeansStateTrackerImpl.java
@@ -247,6 +247,7 @@ final class BeansStateTrackerImpl<BEAN_TYPE> implements
 		removeNotTransientBean(bean.getId(), bean);
 		bean.removeProcessStateListener(processStateListener);
 		removeUnprocessingBean(bean);
+		bean.removeValidationStateListener(validationStateListener);
 		validationDirtyBeans.remove(bean);
 		if (setValidationCacheDirty) {
 			validationCache.setDirty();


### PR DESCRIPTION
from the bean state tracker

Behebt das im Issue beschriebene Problem beim undo.
